### PR TITLE
Improve serial handling and local key error reporting

### DIFF
--- a/custom_components/alsavopro/AlsavoPyCtrl.py
+++ b/custom_components/alsavopro/AlsavoPyCtrl.py
@@ -11,13 +11,18 @@ from .udpclient import UDPClient
 _LOGGER = logging.getLogger(__name__)
 
 
+def sanitize_serial_no(serial_no):
+    """Return serial number containing digits only."""
+    return "".join(ch for ch in str(serial_no) if ch.isdigit())
+
+
 class AlsavoPro:
     """Alsavo Pro data handler."""
 
     def __init__(self, name, serial_no, ip_address, port_no, password):
         """Init Alsavo Pro data handler."""
         self._name = name
-        self._serial_no = serial_no
+        self._serial_no = sanitize_serial_no(serial_no)
         self._ip_address = ip_address
         self._port_no = port_no
         self._password = password
@@ -447,7 +452,13 @@ class AlsavoSocketCom:
         self.lstConfigReqTime = datetime.now()
         if resp is None:
             raise Exception("query_all: no response")
-        return QueryResponse.unpack(resp[0][16:])
+
+        query_response = QueryResponse.unpack(resp[0][16:])
+        if query_response.action == 7 or query_response.parts == 0:
+            raise PermissionError(
+                "Heat pump rejected status query. Check the local key/password used by the integration."
+            )
+        return query_response
 
     async def set_config(self, idx: int, value: int):
         """ Set configuration values on the heat pump """

--- a/custom_components/alsavopro/__init__.py
+++ b/custom_components/alsavopro/__init__.py
@@ -82,7 +82,7 @@ class AlsavoProDataCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         _LOGGER.debug("_async_update_data")
         try:
-            async with async_timeout.timeout(10):
+            async with async_timeout.timeout(30):
                 await self.data_handler.update()
                 return self.data_handler
         except Exception as ex:

--- a/custom_components/alsavopro/udpclient.py
+++ b/custom_components/alsavopro/udpclient.py
@@ -52,10 +52,10 @@ class UDPClient:
         )
 
         try:
-            data = await asyncio.wait_for(future, timeout=5.0)
+            data = await asyncio.wait_for(future, timeout=20.0)
             return data, b'0'
         except asyncio.TimeoutError:
-            _LOGGER.error("Timeout: No response from server in 5 seconds.")
+            _LOGGER.error("Timeout: No response from server in 20 seconds.")
             return None
         finally:
             transport.close()


### PR DESCRIPTION
This PR improves robustness and diagnostics for local Alsavo/Zealux connections.

Changes:
- Strip non-digit characters from the serial number before using it for protocol authentication.
- Detect empty/reset query responses and raise a clearer error suggesting that the local key/password should be checked.
- Increase UDP receive timeout from 5 to 20 seconds.
- Increase Home Assistant coordinator timeout from 10 to 30 seconds.

Background:
While troubleshooting a local pool heat pump setup, the integration could authenticate far enough to receive a handshake but then received reset/empty query responses when the local key was wrong. This resulted in unavailable entities without a useful diagnostic message.

Tested:
- Verified with a local test Home Assistant container.
- Verified successful status/config updates after correcting the local key.
- Verified Python files compile with py_compile.